### PR TITLE
#8991 - support for the dhcp4-change event in qubes-nmhook

### DIFF
--- a/network/qubes-nmhook
+++ b/network/qubes-nmhook
@@ -4,7 +4,7 @@
 # shellcheck source=init/functions
 . /usr/lib/qubes/init/functions
 
-if [ "$2" = "up" ] || [ "$2" = "vpn-up" ] || [ "$2" = "vpn-down" ]; then
+if [ "$2" = "up" ] || [ "$2" = "vpn-up" ] || [ "$2" = "vpn-down" ] || [ "$2" = "dhcp4-change" ]; then
     /usr/lib/qubes/qubes-setup-dnat-to-ns
 
     # FIXME: Tinyproxy does not reload DNS servers.


### PR DESCRIPTION
Fixes [QubesOS/qubes-issues/issues/8991](https://github.com/QubesOS/qubes-issues/issues/8991)